### PR TITLE
Fix : ikettle status not update when you leave the kettle screen and come back later

### DIFF
--- a/android/iKettle2/app/src/main/java/uk/iankent/ikettle2/UseIKettle2.java
+++ b/android/iKettle2/app/src/main/java/uk/iankent/ikettle2/UseIKettle2.java
@@ -210,11 +210,18 @@ public class UseIKettle2 extends AppCompatActivity {
 
         txtName.setText(kettle.Name);
         txtError.setVisibility(View.GONE);
-        client.Connect();
+
         client.onConnected = new OnKettleResponse() {
             @Override
             public void onKettleResponse(KettleResponse response) {
                 client.Process();
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        txtError.setVisibility(View.GONE);
+                        // TODO retry
+                    }
+                });
             }
         };
         client.onDisconnected = new OnKettleResponse() {
@@ -225,6 +232,7 @@ public class UseIKettle2 extends AppCompatActivity {
                     public void run() {
                         txtError.setVisibility(View.VISIBLE);
                         txtError.setText("Disconnected");
+                        txtStatus.setText("Disconnected");
                         // TODO retry
                     }
                 });
@@ -263,5 +271,21 @@ public class UseIKettle2 extends AppCompatActivity {
             // do nothing
         }
         super.onBackPressed();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        try {
+            client.Disconnect();
+        } catch (IOException e) {
+            // do nothing
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        client.Connect();
     }
 }


### PR DESCRIPTION
Instead of calling client.Connect(); in the onCreate I call it in the onResume, and call client.Disconnect(); in the onPause method.
This way it reconnect properly.
We should put the text of the button in a ressource file (If you are ok with that) so we can translate the app in various language easily, does it bother you if I do it ?

Also, I prefer to do many small pull request rather than few big one so you can easily/quickly review the changes, let me know if you prefer the other way around.
